### PR TITLE
allow different oauth connections

### DIFF
--- a/lib/oauth-activeresource.rb
+++ b/lib/oauth-activeresource.rb
@@ -1,18 +1,18 @@
 module OauthActiveResource
   class Base < ActiveResource::Base
     
-    @@oauth_connection = nil
+    @oauth_connection = nil
     
     def self.oauth_connection= connection
-      @@oauth_connection = connection
+      @oauth_connection = connection
     end
         
     def self.oauth_connection
-      @@oauth_connection
+      @oauth_connection
     end
     
     def self.connection(refresh = false)
-      @connection = Connection.new(@@oauth_connection, site,format) if @connection.nil? || refresh
+      @connection = Connection.new(@oauth_connection, site,format) if @connection.nil? || refresh
       @connection.timeout = timeout if timeout
       return @connection
     end


### PR DESCRIPTION
the current implementation shares the connection across all classes, this doesn't allow connections to different apis.
